### PR TITLE
Add WPF WebP image optimizer application

### DIFF
--- a/ImageOptimizerApp.sln
+++ b/ImageOptimizerApp.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageOptimizerApp", "ImageOptimizerApp\\ImageOptimizerApp.csproj", "{B7A0E3D9-45BE-4A49-8BFA-E394371C2C3A}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {B7A0E3D9-45BE-4A49-8BFA-E394371C2C3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B7A0E3D9-45BE-4A49-8BFA-E394371C2C3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B7A0E3D9-45BE-4A49-8BFA-E394371C2C3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B7A0E3D9-45BE-4A49-8BFA-E394371C2C3A}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/ImageOptimizerApp/App.xaml
+++ b/ImageOptimizerApp/App.xaml
@@ -1,0 +1,8 @@
+<Application x:Class="ImageOptimizerApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:ImageOptimizerApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/ImageOptimizerApp/App.xaml.cs
+++ b/ImageOptimizerApp/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace ImageOptimizerApp;
+
+public partial class App : Application
+{
+}

--- a/ImageOptimizerApp/ImageOptimizerApp.csproj
+++ b/ImageOptimizerApp/ImageOptimizerApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp.Formats.Webp" Version="3.0.1" />
+  </ItemGroup>
+</Project>

--- a/ImageOptimizerApp/MainWindow.xaml
+++ b/ImageOptimizerApp/MainWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="ImageOptimizerApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Optimizador de Imágenes WebP" Height="420" Width="720" MinHeight="400" MinWidth="640">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0 0 0 16">
+            <TextBlock Text="Optimizador de imágenes para catálogo" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="Selecciona una carpeta que contenga las imágenes originales. El resultado se guardará en la subcarpeta 'resultado'."
+                       Margin="0 8 0 0" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Margin="0 0 0 16">
+            <DockPanel Margin="0 0 0 8">
+                <TextBox x:Name="FolderPathTextBox" DockPanel.Dock="Left" MinWidth="420" IsReadOnly="True" Margin="0 0 8 0" />
+                <Button x:Name="BrowseButton" Content="Seleccionar carpeta" Padding="12 6" Click="BrowseButton_Click" />
+            </DockPanel>
+            <Button x:Name="StartButton" Content="Comenzar conversión" Padding="12 6" Width="180" Click="StartButton_Click" />
+        </StackPanel>
+
+        <Border Grid.Row="2" x:Name="LoaderPanel" BorderBrush="#FFCCCCCC" BorderThickness="1" CornerRadius="8" Padding="16" Visibility="Collapsed">
+            <StackPanel>
+                <TextBlock x:Name="LoaderText" Text="Procesando imágenes..." FontWeight="SemiBold" HorizontalAlignment="Center" />
+                <ProgressBar x:Name="ConversionProgressBar" Margin="0 16 0 8" Height="18" Minimum="0" Maximum="100" />
+                <TextBlock x:Name="StatusText" Text="Sin iniciar" Margin="0 0 0 4" TextWrapping="Wrap" />
+                <TextBlock x:Name="PercentageText" Text="0%" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/ImageOptimizerApp/MainWindow.xaml.cs
+++ b/ImageOptimizerApp/MainWindow.xaml.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using WinForms = System.Windows.Forms;
+
+namespace ImageOptimizerApp;
+
+public partial class MainWindow : Window
+{
+    private readonly IReadOnlyList<ImageVariant> _variants = new List<ImageVariant>
+    {
+        new("chico", 400, 75),
+        new("mediano", 800, 80),
+        new("grande", 1200, 85)
+    };
+
+    private readonly HashSet<string> _supportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tif", ".tiff"
+    };
+
+    private string? _selectedFolder;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        using var dialog = new WinForms.FolderBrowserDialog
+        {
+            Description = "Selecciona la carpeta origen con las imágenes",
+            UseDescriptionForTitle = true,
+            ShowNewFolderButton = false
+        };
+
+        if (dialog.ShowDialog() == WinForms.DialogResult.OK && Directory.Exists(dialog.SelectedPath))
+        {
+            _selectedFolder = dialog.SelectedPath;
+            FolderPathTextBox.Text = _selectedFolder;
+        }
+    }
+
+    private async void StartButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_selectedFolder) || !Directory.Exists(_selectedFolder))
+        {
+            MessageBox.Show("Selecciona una carpeta de origen válida.", "Carpeta no válida", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var imageFiles = Directory
+            .EnumerateFiles(_selectedFolder, "*.*", SearchOption.TopDirectoryOnly)
+            .Where(path => _supportedExtensions.Contains(Path.GetExtension(path) ?? string.Empty))
+            .OrderBy(path => path)
+            .ToList();
+
+        if (imageFiles.Count == 0)
+        {
+            MessageBox.Show("La carpeta seleccionada no contiene imágenes compatibles.", "Sin imágenes", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        ToggleUi(isProcessing: true);
+
+        var totalSteps = imageFiles.Count * _variants.Count;
+        ConversionProgressBar.Minimum = 0;
+        ConversionProgressBar.Maximum = totalSteps;
+        ConversionProgressBar.Value = 0;
+        PercentageText.Text = "0%";
+        StatusText.Text = "Preparando conversión...";
+
+        var progress = new Progress<ConversionProgress>(progressInfo =>
+        {
+            ConversionProgressBar.Value = progressInfo.CompletedSteps;
+            var percentage = progressInfo.TotalSteps == 0
+                ? 0
+                : (double)progressInfo.CompletedSteps / progressInfo.TotalSteps * 100d;
+
+            PercentageText.Text = $"{percentage:0}%";
+            StatusText.Text = $"Convirtiendo {progressInfo.CurrentFileName} ({progressInfo.CurrentVariant})";
+        });
+
+        try
+        {
+            await Task.Run(() => ProcessImagesAsync(_selectedFolder!, imageFiles, progress));
+            ConversionProgressBar.Value = ConversionProgressBar.Maximum;
+            PercentageText.Text = "100%";
+            StatusText.Text = "Conversión finalizada. Encontrarás los archivos en la carpeta 'resultado'.";
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = "Ocurrió un error durante la conversión.";
+            MessageBox.Show($"Ocurrió un error al convertir las imágenes: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            ToggleUi(isProcessing: false);
+        }
+    }
+
+    private async Task ProcessImagesAsync(string baseFolder, IReadOnlyList<string> imageFiles, IProgress<ConversionProgress> progress)
+    {
+        var resultFolder = Path.Combine(baseFolder, "resultado");
+        Directory.CreateDirectory(resultFolder);
+
+        var step = 0;
+        var totalSteps = imageFiles.Count * _variants.Count;
+
+        foreach (var file in imageFiles)
+        {
+            var fileName = Path.GetFileName(file);
+
+            using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(file);
+
+            foreach (var variant in _variants)
+            {
+                var (width, height) = CalculateTargetSize(image, variant.TargetWidth);
+
+                using Image<Rgba32> clone = image.Clone(context =>
+                {
+                    context.Resize(new ResizeOptions
+                    {
+                        Mode = ResizeMode.Max,
+                        Size = new SixLabors.ImageSharp.Size(width, height)
+                    });
+                });
+
+                var outputFileName = $"{Path.GetFileNameWithoutExtension(file)}_{variant.Name}.webp";
+                var outputPath = Path.Combine(resultFolder, outputFileName);
+
+                var encoder = new WebpEncoder
+                {
+                    Quality = variant.Quality,
+                    FileFormat = WebpFileFormatType.Auto
+                };
+
+                await clone.SaveAsync(outputPath, encoder);
+
+                step++;
+                progress.Report(new ConversionProgress(step, totalSteps, fileName, variant.Name));
+            }
+        }
+    }
+
+    private static (int width, int height) CalculateTargetSize(Image<Rgba32> image, int targetWidth)
+    {
+        if (image.Width <= targetWidth)
+        {
+            return (image.Width, image.Height);
+        }
+
+        var ratio = (double)targetWidth / image.Width;
+        var targetHeight = Math.Max(1, (int)Math.Round(image.Height * ratio));
+        return (targetWidth, targetHeight);
+    }
+
+    private void ToggleUi(bool isProcessing)
+    {
+        if (isProcessing)
+        {
+            LoaderText.Text = "Procesando imágenes...";
+            LoaderPanel.Visibility = Visibility.Visible;
+        }
+        else if (ConversionProgressBar.Maximum > 0 && Math.Abs(ConversionProgressBar.Value - ConversionProgressBar.Maximum) < 0.001)
+        {
+            LoaderText.Text = "Proceso finalizado";
+            LoaderPanel.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            LoaderPanel.Visibility = Visibility.Collapsed;
+        }
+
+        BrowseButton.IsEnabled = !isProcessing;
+        StartButton.IsEnabled = !isProcessing;
+    }
+
+    private record ImageVariant(string Name, int TargetWidth, int Quality);
+
+    private record ConversionProgress(int CompletedSteps, int TotalSteps, string CurrentFileName, string CurrentVariant);
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Prueba1
+# Optimizador de imágenes WebP
+
+Este repositorio incluye una aplicación de escritorio en WPF (.NET 7) que genera versiones optimizadas en formato **WebP** de todas las imágenes contenidas en una carpeta.
+
+## Requisitos
+
+- Visual Studio 2022 (17.4 o superior)
+- SDK de .NET 7
+
+## Ejecución
+
+1. Abre `ImageOptimizerApp.sln` con Visual Studio 2022.
+2. Compila y ejecuta el proyecto `ImageOptimizerApp`.
+3. En la aplicación, selecciona la carpeta de origen que contiene las imágenes a optimizar.
+4. Pulsa **Comenzar conversión** para generar las variantes:
+   - `chico` (≈400px de ancho máximo)
+   - `mediano` (≈800px de ancho máximo)
+   - `grande` (≈1200px de ancho máximo)
+5. Las imágenes convertidas se guardarán dentro de una subcarpeta llamada `resultado` en la misma carpeta de origen.
+
+Durante el proceso se muestra un indicador de progreso, el nombre de la imagen en curso y el porcentaje completado.


### PR DESCRIPTION
## Summary
- add a .NET 7 WPF application that converts images in a selected folder into three WebP sizes with progress feedback
- configure the project with ImageSharp WebP encoders and include a Visual Studio 2022 solution
- document prerequisites and execution steps in the README

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5d8034df8832ca8f4584e32a8daee