### PR TITLE
Remove invalid ImageSharp WebP package reference

### DIFF
--- a/ImageOptimizerApp/ImageOptimizerApp.csproj
+++ b/ImageOptimizerApp/ImageOptimizerApp.csproj
@@ -8,6 +8,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Webp" Version="3.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove the SixLabors.ImageSharp.Webp package reference that is not available on NuGet

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5e2ec52b0832cb459bb9bce22e4e3