### PR TITLE
Fix ImageSharp enum usage for resizing and WebP encoding

### DIFF
--- a/ImageOptimizerApp/MainWindow.xaml.cs
+++ b/ImageOptimizerApp/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using ImageSharpResizeMode = SixLabors.ImageSharp.Processing.ResizeMode;
 using WinForms = System.Windows.Forms;
 
 namespace ImageOptimizerApp;
@@ -129,7 +130,7 @@ public partial class MainWindow : Window
                 {
                     context.Resize(new ResizeOptions
                     {
-                        Mode = ResizeMode.Max,
+                        Mode = ImageSharpResizeMode.Max,
                         Size = new SixLabors.ImageSharp.Size(width, height)
                     });
                 });
@@ -140,7 +141,7 @@ public partial class MainWindow : Window
                 var encoder = new WebpEncoder
                 {
                     Quality = variant.Quality,
-                    FileFormat = WebpFileFormatType.Auto
+                    FileFormat = WebpFileFormatType.Lossy
                 };
 
                 await clone.SaveAsync(outputPath, encoder);


### PR DESCRIPTION
## Summary
- add an alias for the ImageSharp ResizeMode enum to avoid conflicting with WPF
- set the WebP encoder to use the Lossy format supported by the referenced library

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e3d72e3c832c93599b2c341ecdf2