### PR TITLE
Fix WPF spacing property build error

### DIFF
--- a/ImageOptimizerApp/MainWindow.xaml
+++ b/ImageOptimizerApp/MainWindow.xaml
@@ -25,8 +25,8 @@
         </StackPanel>
 
         <GroupBox Grid.Row="2" Header="Configuración de tamaños y calidad" Margin="0 0 0 16">
-            <StackPanel Margin="12 8 12 12" Spacing="12">
-                <TextBlock Text="Las imágenes se redimensionarán manteniendo la proporción original. Configura el ancho máximo para la imagen grande y los porcentajes relativos para las variantes mediana y chica." TextWrapping="Wrap" />
+            <StackPanel Margin="12 8 12 12">
+                <TextBlock Text="Las imágenes se redimensionarán manteniendo la proporción original. Configura el ancho máximo para la imagen grande y los porcentajes relativos para las variantes mediana y chica." TextWrapping="Wrap" Margin="0 0 0 12" />
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
## Summary
- remove the unsupported `Spacing` attribute from the main window StackPanel
- use a margin on the descriptive TextBlock to keep equivalent spacing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5e959146c832ca8f1d56a56b86359