### PR TITLE
Use English names for generated image variants

### DIFF
--- a/ImageOptimizerApp/MainWindow.xaml.cs
+++ b/ImageOptimizerApp/MainWindow.xaml.cs
@@ -274,9 +274,9 @@ public partial class MainWindow : Window
         var mediumWidth = Math.Max(1, (int)Math.Round(largeWidth * mediumPercentage / 100d));
         var smallWidth = Math.Max(1, (int)Math.Round(largeWidth * smallPercentage / 100d));
 
-        variants.Add(new ImageVariant("chico", smallWidth, smallQuality));
-        variants.Add(new ImageVariant("mediano", mediumWidth, mediumQuality));
-        variants.Add(new ImageVariant("grande", largeWidth, largeQuality));
+        variants.Add(new ImageVariant("small", smallWidth, smallQuality));
+        variants.Add(new ImageVariant("medium", mediumWidth, mediumQuality));
+        variants.Add(new ImageVariant("large", largeWidth, largeQuality));
 
         return true;
     }

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Este repositorio incluye una aplicación de escritorio en WPF (.NET 7) que gener
 2. Compila y ejecuta el proyecto `ImageOptimizerApp`.
 3. En la aplicación, selecciona la carpeta de origen que contiene las imágenes a optimizar.
 4. Pulsa **Comenzar conversión** para generar las variantes:
-   - `chico` (≈400px de ancho máximo)
-   - `mediano` (≈800px de ancho máximo)
-   - `grande` (≈1200px de ancho máximo)
+   - `small` (≈400px de ancho máximo)
+   - `medium` (≈800px de ancho máximo)
+   - `large` (≈1200px de ancho máximo)
 5. Las imágenes convertidas se guardarán dentro de una subcarpeta llamada `resultado` en la misma carpeta de origen.
 
 Durante el proceso se muestra un indicador de progreso, el nombre de la imagen en curso y el porcentaje completado.


### PR DESCRIPTION
## Summary
- rename generated image variants to use the English names small, medium, and large
- update the README to document the new variant names

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e710b9ab38832c97a6b0ddfca1ca7a